### PR TITLE
Small changes to the pokemon-card html and css

### DIFF
--- a/content.js
+++ b/content.js
@@ -252,13 +252,13 @@ function createPokemonCardDiv(divId, pokemon) {
 	infoRow.style.display = 'flex';
 
 	const iconWrapper = document.createElement('div');
-  iconWrapper.className = 'pokemon-icon';
-  const icon = document.createElement('img');
-  icon.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`;
-  iconWrapper.appendChild(icon);
-  infoRow.appendChild(iconWrapper);
+  	iconWrapper.className = 'pokemon-icon';
+  	const icon = document.createElement('img');
+  	icon.src = `https://raw.githubusercontent.com/PokeAPI/sprites/master/sprites/pokemon/${pokemon.id}.png`;
+  	iconWrapper.appendChild(icon);
+  	infoRow.appendChild(iconWrapper);
 
-  const weaknessesWrapper = createTypeEffectivenessWrapper('weaknesses', pokemon.typeEffectiveness.weaknesses)
+  	const weaknessesWrapper = createTypeEffectivenessWrapper('weaknesses', pokemon.typeEffectiveness.weaknesses)
 	weaknessesWrapper.appendChild(createTooltipDiv('Weak to'))
 
 	const resistancesWrapper = createTypeEffectivenessWrapper('resistances', pokemon.typeEffectiveness.resistances)
@@ -271,13 +271,19 @@ function createPokemonCardDiv(divId, pokemon) {
 	infoRow.appendChild(resistancesWrapper)
 	infoRow.appendChild(immunitiesWrapper)
 
+	const infoTextWrapper = document.createElement('div');
+	infoTextWrapper.classList.add('info-text-wrapper')
+
 	const extraInfoRow = document.createElement('div');
 	extraInfoRow.classList.add('text-base')
 	extraInfoRow.textContent = `Ability: ${pokemon.ability} - Nature: ${pokemon.nature}`;
 	
-	const ivsRow = document.createElement('div');
-	ivsRow.classList.add('text-base');
-	ivsRow.textContent = `HP: ${pokemon.ivs[Stat["HP"]]}, ATK: ${pokemon.ivs[Stat["ATK"]]}, DEF: ${pokemon.ivs[Stat["DEF"]]}, SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}`;
+	const ivsRowFirst = document.createElement('div');
+	ivsRowFirst.classList.add('text-base');
+	ivsRowFirst.textContent = `HP: ${pokemon.ivs[Stat["HP"]]}, ATK: ${pokemon.ivs[Stat["ATK"]]}, DEF: ${pokemon.ivs[Stat["DEF"]]}`;
+	const ivsRowSecond = document.createElement('div');
+	ivsRowSecond.classList.add('text-base');
+	ivsRowSecond.textContent = `SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}`;
 	
 	let weatherRow = undefined
 	if (weather.type && weather.turnsLeft) {
@@ -286,13 +292,17 @@ function createPokemonCardDiv(divId, pokemon) {
 		weatherRow.textContent = `Weather: ${weather.type}, Turns Left: ${weather.turnsLeft}`
 	}
 
+	infoTextWrapper.appendChild(extraInfoRow)
+	infoTextWrapper.appendChild(ivsRowFirst)
+	infoTextWrapper.appendChild(ivsRowSecond)
+	if (weatherRow) {
+		infoTextWrapper.appendChild(weatherRow)
+	}
+
 	card.appendChild(opacitySliderDiv)
 	card.appendChild(infoRow)
-	card.appendChild(extraInfoRow)
-	card.appendChild(ivsRow)
-	if (weatherRow) {
-		card.appendChild(weatherRow)
-	}
+	card.appendChild(infoTextWrapper)
+	
 	return card
 }
 

--- a/styles.css
+++ b/styles.css
@@ -1,12 +1,7 @@
-:root {
-  --font-size: min(3vh, 2vw);
-  --icon-size: min(10vh, 6vw);
-}
-
 .allies-team {
   margin: 0 auto;
+  padding: 1em;
   position: absolute;
-  top: 0
   bottom: 0;
   right: 0;
   z-index: 1;
@@ -15,11 +10,32 @@
 
 .enemy-team {
   margin: 0 auto;
-  padding: 20px;
+  padding: 1em;
   position: absolute;
   top: 0;
   z-index: 1;
   display: flex;
+}
+
+.allies-team, .enemy-team {
+  max-height: fit-content;
+}
+
+.stat-p {
+  display: flex;
+  padding-right: 0.3em;
+  padding-top: 0.3em;
+}
+
+.stat-c {
+  position: relative;
+  text-shadow: 0.1em 0 rgba(255, 255, 255, 0), -0.1em 0 rgba(255, 255, 255, 0), 0 0.1em rgba(255, 255, 255, 0), 0 -0.1em rgba(255, 255, 255, 0), 0.05em 0.05em rgba(255, 255, 255, 0), -0.05em -0.05em rgba(255, 255, 255, 0), 0.05em -0.05em rgba(255, 255, 255, 0), -0.05em 0.05em rgba(255, 255, 255, 0);
+}
+
+.stat-icon {
+  position: absolute;
+  top: -0.3em;
+  right: -0.5em;
 }
 
 .pokemon-cards {
@@ -33,13 +49,13 @@
   border: 2px solid #555;
   border-radius: 8px;
   flex: 0 0 auto;
-  display:flex;
+  display: flex;
   flex-direction: column;
 }
 
 .pokemon-icon img {
-  width: min(var(--icon-size), 100px);
-  height: min(var(--icon-size), 100px);
+  width: 5em;
+  height: 5em;
 }
 
 .pokemon-info {
@@ -53,24 +69,22 @@
 }
 
 .type-icon {
-  --width: min(calc(var(--icon-size) / 2), 30px);
-  --height: min(calc(var(--icon-size) / 2), 30px);
-  width: var(--width);
-  height: var(--height);
+  width: 1.5em;
+  height: 1.5em;
   background-size: cover;
   background-repeat: no-repeat;
   background-position: left;
-  background-position-x: min(-0.03em, -1.15px);
+  background-position-x: -0.07em;
   border-radius: 50%;
-  margin: 0 5px;
+  margin: 0 0.3em;
 }
 
 .pokemon-weaknesses,
 .pokemon-resistances,
 .pokemon-immunities {
-  min-width: min(calc(var(--icon-size) / 2 + 1vh), 30px);
+  min-width: 2.5em;
   display: flex;
-  justify-content: center;
+  min-height: 5em;
 }
 
 .pokemon-weaknesses {
@@ -97,29 +111,50 @@
   opacity: 1;
 }
 
+.info-text-wrapper .text-base {
+  font-family: lato, tahoma, arial, 'emerald';
+  font-size: .7em;
+  background-color: white;
+  width: fit-content;
+  text-shadow: none;
+  display: block;
+  padding: 2px 2px 0px 2px;
+  line-height: .9em;
+  color: black;
+}
+
 .text-base {
   display: flex;
   font-family: 'emerald';
-  font-size: min(var(--font-size), 18px);
-  text-shadow: 2px 0 #fff, -2px 0 #fff, 0 2px #fff, 0 -2px #fff, 1px 1px #fff, -1px -1px #fff, 1px -1px #fff, -1px 1px #fff;
+  font-size: 1em;
+  text-shadow: 0.1em 0 #fff, -0.1em 0 #fff, 0 0.1em #fff, 0 -0.1em #fff, 0.05em 0.05em #fff, -0.05em -0.05em #fff, 0.05em -0.05em #fff, -0.05em 0.05em #fff;
   color: black;
 }
 
 .arrow-button-wrapper {
   display: grid;
 }
+
 .arrow-button {
-  font-size: min(8vh, 45px)
+  font-size: 2.5em;
+}
+
+.arrow-button-sm {
+  display: block;
+  font-size: 1.15em;
 }
 
 .tooltip .tooltiptext {
   visibility: hidden;
+  font-family: 'emerald';
   text-align: center;
   border-radius: 6px;
-  padding: 5px 0;
-  font-size: var(--font-size);
+  padding: 0.25em 0;
+  font-size: 1em;
   position: absolute;
   z-index: 1;
+  color: black;
+  text-shadow: 0.1em 0 #fff, -0.1em 0 #fff, 0 0.1em #fff, 0 -0.1em #fff, 0.05em 0.05em #fff, -0.05em -0.05em #fff, 0.05em -0.05em #fff, -0.05em 0.05em #fff;
 }
 
 .tooltip:hover .tooltiptext {
@@ -127,38 +162,40 @@
 }
 
 /* Slider settings */
-@media screen and (-webkit-min-device-pixel-ratio:0) {
-    input[type='range'] {
-      overflow: hidden;
-      width: 20vh;
-      -webkit-appearance: none;
-    }
-    
-    input[type='range']::-webkit-slider-runnable-track {
-      height: 1vh;
-      -webkit-appearance: none;
-      color: #13bba4;
-      margin-top: -1px;
-    }
-    
-    input[type='range']::-webkit-slider-thumb {
-      width: 1vh;
-      -webkit-appearance: none;
-      height: 1vh;
-      cursor: ew-resize;
-      box-shadow: -8vh 0 0 8vh #b3462c;
-    }
+@media screen and (-webkit-min-device-pixel-ratio: 0) {
+  input[type='range'] {
+    overflow: hidden;
+    width: 4em;
+    -webkit-appearance: none;
+  }
 
+  input[type='range']::-webkit-slider-runnable-track {
+    height: 10px;
+    -webkit-appearance: none;
+    color: #13bba4;
+    margin-top: -1px;
+  }
+
+  input[type='range']::-webkit-slider-thumb {
+    width: 10px;
+    -webkit-appearance: none;
+    height: 10px;
+    cursor: ew-resize;
+    box-shadow: -80px 0 0 80px #b3462c;
+  }
 }
-/** FF*/
+
+/* FF */
 input[type="range"]::-moz-range-progress {
   background-color: #b3462c;
 }
-input[type="range"]::-moz-range-track {  
+
+input[type="range"]::-moz-range-track {
   background-color: #fff;
 }
+
 input[type="range"] {
-  background-color:transparent
+  background-color: transparent;
 }
 
 .slider-wrapper {


### PR DESCRIPTION
Changes according to my suggestion on discord https://discord.com/channels/1238895022502580235/1240216698590593096.
I haven't touched the arrow buttons or the opacity slider. The buttons need even more HTML changes, the slider needs to be added to the options menu first.

HTML changes are untested because the current extension doesn't work (as opposed to the unstable version that doesn't have a Github branch, nor the actual development files included) and I don't know how to build the project.

The changes look like a lot until you view them while using the `Ignore Whitespaces` option. 
I have used the `style.css` file from the unstable version since that one seems to be more up to date already.

