### PR TITLE
Links to wiki

### DIFF
--- a/libs/httputils.js
+++ b/libs/httputils.js
@@ -35,19 +35,19 @@ function _createPokemonCardDiv(cardclass, cardId, pokemon) {
 	        HP: ${pokemon.ivs[Stat["HP"]]}, ATK: ${pokemon.ivs[Stat["ATK"]]}, DEF: ${pokemon.ivs[Stat["DEF"]]}
 	      </div>
 	      <table style="border:0px solid transparent;">
-					<tbody>
-						<tr>
-							<td>
-								<div class="text-base">
-	        				SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}
-	      				</div>
-							</td>
-							<td>
-								<a style="text-align: end; display: block;" class="text-base" href="https://wiki.pokerogue.net/pokedex:${pokemon.id}">wiki</a>
-							</td>
-							</tr>
-					</tbody>
-				</table>	        
+	        <tbody>
+	          <tr>
+	            <td>
+	              <div class="text-base">
+	                SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}
+	              </div>
+	            </td>
+	            <td>
+	              <a style="text-align: end; display: block;" class="text-base" href="https://wiki.pokerogue.net/pokedex:${pokemon.id}">wiki</a>
+	            </td>
+	            </tr>
+	        </tbody>
+	      </table>	        
 	      ${(_weather.type && _weather.turnsLeft) ? 
 	        `<div class="text-base">_weather: ${_weather.type}, Turns Left: ${_weather.turnsLeft}</div>` 
 	      : ''}

--- a/libs/httputils.js
+++ b/libs/httputils.js
@@ -34,10 +34,20 @@ function _createPokemonCardDiv(cardclass, cardId, pokemon) {
 	      <div class="text-base">
 	        HP: ${pokemon.ivs[Stat["HP"]]}, ATK: ${pokemon.ivs[Stat["ATK"]]}, DEF: ${pokemon.ivs[Stat["DEF"]]}
 	      </div>
-	      <div class="text-base">
-	        SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}
-	      </div>
-	        
+	      <table style="border:0px solid transparent;">
+					<tbody>
+						<tr>
+							<td>
+								<div class="text-base">
+	        				SPE: ${pokemon.ivs[Stat["SPD"]]}, SPD: ${pokemon.ivs[Stat["SPDEF"]]}, SPA: ${pokemon.ivs[Stat["SPATK"]]}
+	      				</div>
+							</td>
+							<td>
+								<a style="text-align: end; display: block;" class="text-base" href="https://wiki.pokerogue.net/pokedex:${pokemon.id}">wiki</a>
+							</td>
+							</tr>
+					</tbody>
+				</table>	        
 	      ${(_weather.type && _weather.turnsLeft) ? 
 	        `<div class="text-base">_weather: ${_weather.type}, Turns Left: ${_weather.turnsLeft}</div>` 
 	      : ''}


### PR DESCRIPTION
This adds a link to the pokerogue wiki based on `pokemon.id`.  
I find myself checking the wiki often, and this will make opening it easier without any major UI changes
![](https://i.imgur.com/02zEi9m.png)
![](https://i.imgur.com/7y9SpEo.png)